### PR TITLE
CI: No Python 3.11

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -2,15 +2,9 @@ name: docs
 
 on:
   push:
-    paths:
-      - '.github/workflows/docs.yaml'
-      - 'docs/**'
-      - 'pydra/**'
+    branches: [ main ]
   pull_request:
-    paths:
-      - '.github/workflows/docs.yaml'
-      - 'docs/**'
-      - 'pydra/**'
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -29,7 +23,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '3.x'
+          python-version: '3.10'
       - name: Install Hatch
         run: pipx install hatch
       - name: Build documentation

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,11 +2,9 @@ name: test
 
 on:
   push:
-    branches:
-      - main
+    branches: [ main ]
   pull_request:
-    branches:
-      - main
+    branches: [ main ]
   workflow_dispatch:
 
 permissions:
@@ -34,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-        python-version: [ '3.7', '3.8', '3.9', '3.10', '3.11' ]
+        python-version: [ '3.7', '3.8', '3.9', '3.10' ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Because no stable release of Numba supports it [yet](https://github.com/numba/numba/issues/8304).